### PR TITLE
Fix lockingrange

### DIFF
--- a/linux/DtaDevLinuxDrive.cpp
+++ b/linux/DtaDevLinuxDrive.cpp
@@ -31,7 +31,7 @@ uint8_t DtaDevLinuxDrive::prepareForS3Sleep(uint8_t lockingrange, const vector<u
     opal_lock_unlock opal_ioctl_data={};
     opal_ioctl_data.l_state = OPAL_RW;
     opal_ioctl_data.session.who = OPAL_ADMIN1;
-    opal_ioctl_data.session.opal_key.lr = 0;
+    opal_ioctl_data.session.opal_key.lr = lockingrange;
 
     size_t hash_len=min(password_hash.size(), sizeof(opal_ioctl_data.session.opal_key.key));
     LOG(D2) << "Setting a hash of length" << hash_len;

--- a/linux/DtaDevOS.cpp
+++ b/linux/DtaDevOS.cpp
@@ -189,7 +189,7 @@ uint8_t DtaDevOS::prepareForS3Sleep(uint8_t lockingrange, char* password)
     DtaHashPwd(hash, password, this);
     hash.erase(hash.begin(), hash.begin()+2);
 
-    err = drive->prepareForS3Sleep(0, hash);
+    err = drive->prepareForS3Sleep(lockingrange, hash);
     if (err)
     {
         LOG(E) << "Error saving the password to  the kernel errno = " << errno;


### PR DESCRIPTION
Code is currently fixated to global region (0) and the passed argument is ignored. This PR fixes that. I tested with another region, works like a charm.